### PR TITLE
Task 3: Display "where you are on the page" in the global header

### DIFF
--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -1,12 +1,24 @@
+"use client";
+
 import { AppBar, Box, Toolbar, Typography } from "@mui/material";
 import PeopleIcon from "@mui/icons-material/People";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+
 
 export interface GlobalHeaderProps {
   title: string;
 }
 
+const pageTitles: Record<string, string> = {
+  "/": "社員検索",
+  "/employee": "社員詳細",
+};
+
 export function GlobalHeader({ title }: GlobalHeaderProps) {
+  const pathname = usePathname();
+  const currentPage = pageTitles[pathname] ?? pathname;
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -21,10 +33,16 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
             <PeopleIcon fontSize={"large"} sx={{ mr: 2 }} />
           </Link>
           <Link href="/">
-            <Typography variant="h6" component="h1" sx={{ flexGrow: 1 }}>
+            <Typography variant="h6" component="h1" sx={{ flexGrow: 1, mr: 1 }}>
               {title}
             </Typography>
           </Link>
+          <Typography variant="h6" component="h1" sx={{ mr: 1 }}>
+            -
+          </Typography>
+          <Typography variant="h6" component="h1" sx={{ flexGrow: 1, mr: 1 }}>
+            {currentPage}
+          </Typography>
         </Toolbar>
       </AppBar>
     </Box>


### PR DESCRIPTION
# 概要
グローバルヘッダに、「社員検索」や「社員詳細」など、「自分が今どのページにいるのか」を表示する機能を実装しました。

# 詳細
usePathnameを利用してPathを取得し、あらかじめ設定したPathとページ名の対応付けをもとに、ページ名を表示しています。
今後、ページが増えた場合は修正が必要です。
参考：https://qiita.com/RANZU/items/0037cbb04d8716944b0e