### PR TITLE
カードの内部の拡充と名前の省略設定

### DIFF
--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -61,11 +61,23 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
           alignItems="center"
           p={2}
           gap={2}
+          width="100%"
         >
           <Avatar sx={{ width: 128, height: 128 }}>
             <PersonIcon sx={{ fontSize: 128 }} />
           </Avatar>
-          <Typography variant="h5">{employee.name}</Typography>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              variant="h5"
+              sx={{
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {employee.name}
+            </Typography>
+          </Box>
         </Box>
         <Box sx={{ borderBottom: 1, borderColor: "divider", width: "100%" }}>
           <Tabs value={selectedTabValue} onChange={handleTabValueChange}>
@@ -79,8 +91,8 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
             <Typography variant="h6">基本情報</Typography>
             <Typography>年齢：{employee.age}歳</Typography>
             <Typography>所属：{employee.affiliation}</Typography>
-            <Typography>役職：{employee.post}</Typography>            
-            <Typography>スキル：{employee.skills.join(', ')}</Typography>            
+            <Typography>役職：{employee.post}</Typography>
+            <Typography>スキル：{employee.skills.join(', ')}</Typography>
           </Box>
         </TabContent>
 

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -32,8 +32,23 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
               <Avatar sx={{ width: 48, height: 48 }}>
                 <PersonIcon sx={{ fontSize: 48 }} />
               </Avatar>
-              <Box display="flex" flexDirection="column">
-                <Typography>{employee.name}</Typography>
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <Typography variant="h6" component="div" sx={{
+                  whiteSpace: "nowrap",    // テキストを折り返さない
+                  overflow: "hidden",        // はみ出した部分を隠す
+                  textOverflow: "ellipsis",  // はみ出した部分を「...」で表示
+                }}>
+                  {employee.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {`所属: ${employee.affiliation}`}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="body2" color="text.secondary"
+                  sx={{ whiteSpace: 'nowrap' }}>
+                  {`${employee.age}歳`}
+                </Typography>
               </Box>
             </Box>
           </CardContent>
@@ -51,7 +66,7 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
       >
         <Card
           sx={{
-            width: 200,
+            width: 225,
             height: 200,
             transition: "background-color 0.2s",
             "&:hover": {
@@ -59,18 +74,35 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
             },
           }}
         >
-          <CardContent>
+          <CardContent sx={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center'
+          }}>
             <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
               <Avatar sx={{ width: 48, height: 48 }}>
                 <PersonIcon sx={{ fontSize: 48 }} />
               </Avatar>
-              <Box display="flex" flexDirection="column">
-                <Typography>{employee.name}</Typography>
+              <Box display="flex" flexDirection="column" sx={{ flexGrow: 1, minWidth: 0 }}>
+                <Typography variant="h6" component="div" sx={{
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}>
+                  {employee.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {`${employee.affiliation}`}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {`${employee.age}歳`}
+                </Typography>
               </Box>
             </Box>
           </CardContent>
         </Card>
-      </Link>
+      </Link >
     );
   }
 


### PR DESCRIPTION
# 概要
カード内部に所属と年齢を記載するようにしました。
氏名が長すぎた際に、改行されるのではなく、省略されるようにしました。

# 注意
他の項目も飛び出てしまったり、改行される可能性があるので、チェックした方が良いかもしれません。
今回は時間の都合上名前だけです。

# 生成AIの利用
Gemini：https://g.co/gemini/share/7942a6df95a8