### PR TITLE
Task 自由課題11: AWSへのデプロイ

### DIFF
--- a/backend-ts/package.json
+++ b/backend-ts/package.json
@@ -13,7 +13,6 @@
   "license": "ISC",
   "description": "A simple talent management app",
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.788.0",
     "@eslint/eslintrc": "^3.3.1",
     "@types/aws-lambda": "^8.10.149",
     "@types/express": "^5.0.1",
@@ -28,6 +27,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.788.0",
     "io-ts": "^2.2.22"
   }
 }

--- a/cdk-ts/deploy.bash
+++ b/cdk-ts/deploy.bash
@@ -5,9 +5,10 @@ PROJECT_ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 
 echo "Building backend."
 cd "$PROJECT_ROOT_DIR/backend-ts"
-npm ci
 mkdir -p "layers/nodejs" 
-cp -r node_modules "layers/nodejs/node_modules"
+cp package-lock.json "layers/nodejs/package-lock.json"
+cp package.json "layers/nodejs/package.json"
+npm ci --omit=dev --prefix "layers/nodejs"
 npm run build
 cd -
 


### PR DESCRIPTION
# 概要
AWSへデプロイできるようにした。

# 詳細
デプロイする際に、バックエンドのnode_moduleフォルダが大きすぎてエラーを吐いたので、梶原さんに手伝ってもらいながらdeploy.bashを修正して対応した。